### PR TITLE
run QR decomposition if LU decomposition fails

### DIFF
--- a/R/tracemin.R
+++ b/R/tracemin.R
@@ -5,6 +5,17 @@
 #        minimization
 # All these functions return a reverse reconciled matrix with all ts.
 
+#LU decomposition is fast but sometimes instable. Use QR decomposition of LU decomposition fails
+solveLUQR <- function(lhs.l, rhs.l) {
+  tryCatch(solve(lhs.l, rhs.l), error=function(cond){
+        
+        #browser()
+        warning("An error in LU decomposition occurred, the message was the following:\n", 
+            cond$message, "\n Trying QR decomposition instead...")
+        solve(qr(lhs.l), rhs.l)
+      })  
+} 
+
 # LU factorization (Matrix pkg)
 LU <- function(fcasts, S, weights) {
   nts <- nrow(S)
@@ -19,12 +30,12 @@ LU <- function(fcasts, S, weights) {
   if (is.null(weights)) {
     lhs.l <- utmat %*% t(utmat)
     lhs.l <- (t(lhs.l) + lhs.l)/2
-    lin.sol <- solve(lhs.l, rhs.l)
+    lin.sol <- solveLUQR(lhs.l, rhs.l)
     p1 <- jmat %*% fcasts - (jmat %*% t(utmat) %*% lin.sol)
   } else {
     lhs.l <- utmat %*% weights %*% t(utmat)
     lhs.l <- (t(lhs.l) + lhs.l)/2
-    lin.sol <- solve(lhs.l, rhs.l)
+    lin.sol <- solveLUQR(lhs.l, rhs.l)
     p1 <- jmat %*% fcasts - (jmat %*% weights %*% t(utmat) %*% lin.sol)
   }
   comb <- as.matrix(S %*% p1)


### PR DESCRIPTION
I had the following problem various times with fairly big hierarchies:

> fc <- forecast(groupedSeries, parallel=TRUE, num.cores=2)
Error in LU.dgC(a) : cs_lu(A) failed: near-singular A (or out of memory)

Enter a frame number, or 0 to exit  

1: forecast(groupedSeries, parallel = TRUE, num.cores = 2)
2: forecast.gts(groupedSeries, parallel = TRUE, num.cores = 2)
3: Comb(pfcasts, weights = wvec, keep = "bottom", algorithms = alg)
4: hts.R#178: combinef(x, groups = object$groups, ...)
5: LU(fcasts = fcasts, S = smat, weights = weights)
6: solve(lhs.l, rhs.l)
7: solve(lhs.l, rhs.l)
8: .local(a, b, ...)
9: solve(forceCspSymmetric(a, isTri = FALSE), b, tol = tol)
10: solve(forceCspSymmetric(a, isTri = FALSE), b, tol = tol)
11: .local(a, b, ...)
12: solve.dsC.dC(a, b, LDL = LDL, tol = tol)
13: .solve.dgC.lu(as(a, "dgCMatrix"), b = b, tol = tol)
14: LU.dgC(a)

This patch solves this issue by running a QR decomposition if the LU decomposition fails. The QR decomposition takes considerably longer and also takes a lot of memory, but less than other possibilities that I evaluated. Another advantage is that it is directly available in the Matrix package.
